### PR TITLE
CircuitBreaker interface Extracted to make it mockable

### DIFF
--- a/CircuitBreaker/CircuitBreaker.cs
+++ b/CircuitBreaker/CircuitBreaker.cs
@@ -9,7 +9,7 @@ namespace DistributedCircuitBreaker
     /// <summary>
     /// Responsible for controlling the circuit Break, validate if the rules are broken
     /// </summary>
-    public class CircuitBreaker
+    public class CircuitBreaker : ICircuitBreaker
     {
         private List<IRule> _rules;
         private HealthCount _healthCount ;

--- a/CircuitBreaker/Core/CircuitBreakerFactory.cs
+++ b/CircuitBreaker/Core/CircuitBreakerFactory.cs
@@ -23,7 +23,7 @@ namespace DistributedCircuitBreaker.Core
         /// <exception cref="System.ArgumentException">key;key must be provided</exception>
         /// <exception cref="System.ArgumentException">rules;At least one rule must be provided</exception>
         /// <exception cref="System.ArgumentException">repository;Repository could not be null</exception>
-        public CircuitBreaker Create(string key,  List<IRule> rules)
+        public ICircuitBreaker Create(string key,  List<IRule> rules)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentException("key must be provided");
@@ -46,7 +46,7 @@ namespace DistributedCircuitBreaker.Core
         /// <exception cref="System.ArgumentException">key;key must be provided</exception>
         /// <exception cref="System.ArgumentException">rules;At least one rule must be provided</exception>
         /// <exception cref="System.ArgumentException">repository;Repository could not be null</exception>
-        public CircuitBreaker Create(string key, int exceptionsAllowedBeforeBreaking, decimal failureRateAllowed)
+        public ICircuitBreaker Create(string key, int exceptionsAllowedBeforeBreaking, decimal failureRateAllowed)
         {
             var rules = new List<IRule>()
             {
@@ -67,7 +67,7 @@ namespace DistributedCircuitBreaker.Core
         /// <exception cref="System.ArgumentException">key;key must be provided</exception>
         /// <exception cref="System.ArgumentException">rules;At least one rule must be provided</exception>
         /// <exception cref="System.ArgumentException">repository;Repository could not be null</exception>
-        public CircuitBreaker Create(string key,int exceptionsAllowedBeforeBreaking)
+        public ICircuitBreaker Create(string key,int exceptionsAllowedBeforeBreaking)
         {
             var rules = new List<IRule>()
             {

--- a/CircuitBreaker/Core/ICircuitBreakerFactory.cs
+++ b/CircuitBreaker/Core/ICircuitBreakerFactory.cs
@@ -12,7 +12,7 @@ namespace DistributedCircuitBreaker.Core
         /// <returns>new instance of CircuitBreaker</returns>
         /// <exception cref="System.ArgumentException">key;key must be provided</exception>
         /// <exception cref="System.ArgumentException">rules;At least one rule must be provided</exception>
-        CircuitBreaker Create(string key, List<IRule> rules);
+        ICircuitBreaker Create(string key, List<IRule> rules);
         /// <summary>
         /// Initializes an instance of CircuitBreaker 
         /// CircuitBreaker will be configured with Fixed number of exceptions allowed before break also considering a proportion of failures compared to total executions
@@ -24,7 +24,7 @@ namespace DistributedCircuitBreaker.Core
         /// <returns>new instance of CircuitBreaker</returns>
         /// <exception cref="System.ArgumentException">key;key must be provided</exception>
         /// <exception cref="System.ArgumentException">rules;At least one rule must be provided</exception>
-        CircuitBreaker Create(string key, int exceptionsAllowedBeforeBreaking, decimal failureRateAllowed);
+        ICircuitBreaker Create(string key, int exceptionsAllowedBeforeBreaking, decimal failureRateAllowed);
         /// <summary>
         /// Initializes an instance of CircuitBreaker 
         /// CircuitBreaker will be configured with Fixed number of exceptions allowed before break
@@ -34,6 +34,6 @@ namespace DistributedCircuitBreaker.Core
         /// <returns>new instance of CircuitBreaker</returns>
         /// <exception cref="System.ArgumentException">key;key must be provided</exception>
         /// <exception cref="System.ArgumentException">rules;At least one rule must be provided</exception>
-        CircuitBreaker Create(string key, int exceptionsAllowedBeforeBreaking);
+        ICircuitBreaker Create(string key, int exceptionsAllowedBeforeBreaking);
     }
 }

--- a/CircuitBreaker/DistributedCircuitBreaker.csproj
+++ b/CircuitBreaker/DistributedCircuitBreaker.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageProjectUrl>https://github.com/luizalabs/DistributedCircuitBreaker.NET</PackageProjectUrl>
   </PropertyGroup>
 

--- a/CircuitBreaker/ICircuitBreaker.cs
+++ b/CircuitBreaker/ICircuitBreaker.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using DistributedCircuitBreaker.Core;
+
+namespace DistributedCircuitBreaker
+{
+    public interface ICircuitBreaker
+    {
+        CircuitState State { get; }
+
+        void ExecuteAction(Action action);
+        TResult ExecuteAction<TResult>(Func<TResult> action);
+        Task ExecuteActionAsync(Func<Task> action);
+        Task<TResult> ExecuteActionAsync<TResult>(Func<Task<TResult>> action);
+        bool IsOpen();
+    }
+}

--- a/DistributedCircuitbreaker.Redis/DistributedCircuitbreaker.Redis.csproj
+++ b/DistributedCircuitbreaker.Redis/DistributedCircuitbreaker.Redis.csproj
@@ -7,13 +7,13 @@
     <Company>Luizalabs</Company>
     <Product>DistributedCircuitbreaker.Redis</Product>
     <Description>DistributedCiscuitBreaker.Redis is an implementation of IDistributedCircuitBreakerRepository using Redis</Description>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageProjectUrl>https://github.com/luizalabs/DistributedCircuitBreaker.NET</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DistributedCircuitBreaker" Version="1.0.0" />
+    <PackageReference Include="DistributedCircuitBreaker" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />


### PR DESCRIPTION
extracted circuit breaker interface to allows developers to mock the behavior, since CircuitBreaker constructor is internal.